### PR TITLE
Fix mixins of _MultiAxisDismissiblePageState

### DIFF
--- a/lib/src/multi_axis_dismissible_page.dart
+++ b/lib/src/multi_axis_dismissible_page.dart
@@ -58,7 +58,7 @@ class MultiAxisDismissiblePage extends StatefulWidget {
 }
 
 class _MultiAxisDismissiblePageState extends State<MultiAxisDismissiblePage>
-    with Drag, SingleTickerProviderStateMixin, _DismissiblePageMixin {
+    with SingleTickerProviderStateMixin, _DismissiblePageMixin implements Drag {
   late final GestureRecognizer _recognizer;
   late final ValueNotifier<DismissiblePageDragUpdateDetails> _dragNotifier;
   Offset _startOffset = Offset.zero;


### PR DESCRIPTION
_MultiAxisDismissiblePageState was using Drag as a mixin.
Drag should be implemented instead of being mixed, because it'a an abstract class.